### PR TITLE
Known .com's too broad

### DIFF
--- a/lib/fat_fingers.rb
+++ b/lib/fat_fingers.rb
@@ -108,7 +108,7 @@ protected
   end
 
   def clean_up_known_coms
-    gsub(/(aol|googlemail|gmail|hotmail|yahoo|icloud|outlook)\.(co|net|org)$/, '\1.com')
+    gsub(/(@aol|googlemail|@gmail|hotmail|yahoo|icloud|outlook)\.(co|net|org)$/, '\1.com')
   end
 
   def add_a_period_if_they_forgot_it

--- a/test/test_fat_fingers.rb
+++ b/test/test_fat_fingers.rb
@@ -287,7 +287,9 @@ class StringTest < MiniTest::Unit::TestCase
       "test@ymail.com",
       "test@army.mil",
       "test@anything.comcast.com",
-      "test@anything.comcastbiz.net"
+      "test@anything.comcastbiz.net",
+      "test@dogmail.net",
+      "test@engaol.net"
     ]
 
 


### PR DESCRIPTION
This change prevents unnecessarily broad matching for "known .com domains".  Any domain ending in `gmail` such as `dogmail.net` will get updated incorrectly. 

```
test@chengmail.net --> test@chengmail.com
```