### PR TITLE
[FIX] Adding ac.in for indian acedemic sites

### DIFF
--- a/lib/fat_fingers.rb
+++ b/lib/fat_fingers.rb
@@ -80,11 +80,11 @@ protected
   end
 
   def clean_up_googlemail
-    gsub(/@go{0,3}g{0,2}o?le?[mn]?[ail]{1,2}m?[aikl]{0,3}\./,"@googlemail.")
+    gsub(/@go{0,3}g{0,2}o?le?[mn]?[ail]{1,2}m?[aikl]{0,3}\.(?!gov)(?!edu)(?!ac.in)/,"@googlemail.")
   end
 
   def clean_up_gmail
-    gsub(/@ga?e?i?o?r?g?[nm]{0,2}s?[ail]{1,2}[aiklmou]{0,3}\.(?!gov)(?!edu)/,"@gmail.") # match a broad variety of mispellings of gmail, but not if it's .gov or .edu
+    gsub(/@ga?e?i?o?r?g?[nm]{0,2}s?[ail]{1,2}[aiklmou]{0,3}\.(?!gov)(?!edu)(?!ac.in)/,"@gmail.") # match a broad variety of mispellings of gmail, but not if it's .gov or .edu
   end
 
   def clean_up_hotmail

--- a/test/test_fat_fingers.rb
+++ b/test/test_fat_fingers.rb
@@ -278,6 +278,8 @@ class StringTest < MiniTest::Unit::TestCase
       "test@gmx.com",
       "test@gao.gov",
       "test@gial.edu",
+      "test@gial.ac.in",
+      "test@gla.gov",
       "test@googlemail.com",
       "test@something.cn",
       "test@something.com.co",


### PR DESCRIPTION
Hi @charliepark,
We use this gem in our projects. Our main users are college students. In this repo you have included academic sites by adding `edu` in the regex. In India academic sites uses the tld `ac.in`. We recently ran into a problem from one college `http://gla.ac.in/` where users have email as gla which is similar with gmail their emails were changed to gmail from gla.ac.in in our database. I have fixed this issue and have added tests also so that others who use this gem from India do not run to this type of problem again.

Added test for:
1. Indian academic sites e.g. gla.ac.in
2. `gov` and `edu` are not in the regex of googlemail, added them in the regex and added in test also.

PS: Thanks for making this gem ❤